### PR TITLE
Fix linking on macOS

### DIFF
--- a/crates/native/.cargo/config
+++ b/crates/native/.cargo/config
@@ -1,0 +1,6 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]
+

--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,8 @@
         {erl_opts, [no_debug_info, warnings_as_errors]},
         {relx, [{dev_mode, false}, {include_erts, true}, {include_src, false}]},
         {pre_hooks, [
-          {"(linux|darwin|solaris|freebsd)", compile, "sh -c \"cd crates/native && cargo build --release && cp target/release/libnative.so ../../priv/\""}
+          {"(linux|solaris|freebsd)", compile, "sh -c \"cd crates/native && cargo build --release && cp target/release/libnative.so ../../priv/\""},
+          {"(darwin)", compile, "sh -c \"cd crates/native && cargo build --release && cp target/release/libnative.dylib ../../priv/libnative.so\""}
         ]}
     ]},
 
@@ -43,7 +44,8 @@
         {erl_opts, [debug_info, warnings_as_errors, nowarn_export_all]},
         {relx, [{dev_mode, true}, {include_erts, false}, {include_src, false}]},
         {pre_hooks, [
-          {"(linux|darwin|solaris|freebsd)", compile, "sh -c \"cd crates/native && cargo build && cp target/debug/libnative.so ../../priv/\""}
+          {"(linux|solaris|freebsd)", compile, "sh -c \"cd crates/native && cargo build && cp target/debug/libnative.so ../../priv/\""},
+          {"(darwin)", compile, "sh -c \"cd crates/native && cargo build && cp target/debug/libnative.dylib ../../priv/libnative.so\""}
         ]}
     ]},
 
@@ -51,7 +53,8 @@
         {erl_opts, [debug_info, warnings_as_errors, nowarn_export_all]},
         {relx, [{dev_mode, true}, {include_erts, false}, {include_src, false}]},
         {pre_hooks, [
-          {"(linux|darwin|solaris|freebsd)", compile, "sh -c \"cd crates/native && cargo build && cp target/debug/libnative.so ../../priv/\""}
+          {"(linux|solaris|freebsd)", compile, "sh -c \"cd crates/native && cargo build && cp target/debug/libnative.so ../../priv/\""},
+          {"(darwin)", compile, "sh -c \"cd crates/native && cargo build && cp target/debug/libnative.dylib ../../priv/libnative.so\""}
         ]}
     ]},
 


### PR DESCRIPTION
NIFs depend on external ERTS symbols already loaded by BEAM before the NIF module is loaded. On macOS, this lack of link-time symbols causes errors. The idiomatic solution is to provided the linker args `-undefined,dynamic_lookup`.

Additionally, shared dynamic libraries on macOS have the extension `.dylib`.  Since `rustc` and `cargo` provide no way of overriding the library suffice, we need to modify how rebar3 installs the rust lib on macOS.