### PR TITLE
Update for LDPC/Robust sol

### DIFF
--- a/crates/native/Cargo.toml
+++ b/crates/native/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["dylib"]
 
 [dependencies]
 rustler = { git = "https://github.com/rusterlium/rustler.git", branch = "master" }
-fountaincode = { git = 'https://github.com/vihu/fountain', branch = "master"}
+fountaincode = { git = 'https://github.com/refugeesus/fountain.git', rev = "db1f81b14661dd02217d1316f78bd06857868d7b" }
+labrador-ldpc = "1.0.0"

--- a/crates/native/src/atoms.rs
+++ b/crates/native/src/atoms.rs
@@ -7,4 +7,11 @@ rustler::atoms! {
     edges,
     random,
     systematic,
+    tc128,
+    tc256,
+    tc512,
+    tm1280,
+    tm5120,
+    tm6144,
+    tm8192,
 }

--- a/crates/native/src/decoder.rs
+++ b/crates/native/src/decoder.rs
@@ -1,10 +1,11 @@
-use crate::atoms::{missing, finished, seeded, edges};
-use rustler::{Env, Encoder, OwnedBinary, Binary, Term, Error, NifResult};
+use crate::atoms::{missing, finished, seeded, edges, tc128, tc256, tc512};
+use rustler::{Env, Encoder, OwnedBinary, Binary, Term, Error, NifResult, Atom};
 use rustler::resource::ResourceArc;
 use rustler::types::tuple::get_tuple;
-use fountaincode::decoder::Decoder as FountainDecoder;
-use fountaincode::droplet::Droplet;
-use fountaincode::types::{DropType, CatchResult};
+use fountaincode::decoder::{Decoder as FountainDecoder, CatchResult};
+use fountaincode::droplet::{Droplet, DropType};
+use fountaincode::ldpc::{droplet_decode, DecoderType};
+use labrador_ldpc::LDPCCode;
 use std::sync::RwLock;
 use std::io::Write;
 
@@ -24,6 +25,99 @@ fn new_decoder(len: usize, chunk: usize) -> ResourceArc<DecoderRes> {
     });
 
     resource
+}
+
+#[rustler::nif(name = "catch_drop_ldpc")]
+fn catch_drop_ldpc<'a>(
+    env: Env<'a>,
+    decoder_res: ResourceArc<DecoderRes>,
+    drop: Term<'a>,
+    decoder_type: Atom) -> NifResult<Term<'a>> {
+    let mut dec = decoder_res.decoder.write().unwrap();
+
+    let drop_tuple = get_tuple(drop);
+
+    match drop_tuple {
+        Ok(tup) => {
+            let first = get_tuple(tup[0]);
+
+            match first {
+                Ok(edge_or_seeded) => {
+                    if edge_or_seeded[0] == edges().to_term(env) {
+                        // Do edges stuff
+                        let cnt: usize = edge_or_seeded[1].decode().unwrap();
+                        let drop_data = tup[1].into_binary().unwrap();
+                        let mut droplet = Droplet::new(DropType::Edges(cnt), drop_data.to_vec());
+                        if decoder_type == tc128() {
+                            droplet_decode(&mut droplet, LDPCCode::TC128, DecoderType::Ms);
+                        } else if decoder_type == tc256() {
+                            droplet_decode(&mut droplet, LDPCCode::TC256, DecoderType::Ms);
+                        } else if decoder_type == tc512() {
+                            droplet_decode(&mut droplet, LDPCCode::TC512, DecoderType::Ms);
+                        } else {
+                            return Err(Error::BadArg)
+                        }
+                        match dec.catch(droplet) {
+                            CatchResult::Missing(stats) => {
+                                Ok(
+                                    (missing(),
+                                    (stats.cnt_droplets, stats.cnt_chunks, stats.overhead, stats.unknown_chunks)).encode(env)
+                                )
+                            }
+                            CatchResult::Finished(data, stats) => {
+                                let mut binary = OwnedBinary::new(data.len()).unwrap();
+                                binary.as_mut_slice().write_all(&data).unwrap();
+                                Ok(
+                                    (finished(),
+                                    Binary::from_owned(binary, env),
+                                    (stats.cnt_droplets, stats.cnt_chunks, stats.overhead, stats.unknown_chunks)).encode(env)
+                                )
+                            }
+                        }
+                    } else if edge_or_seeded[0] == seeded().to_term(env) {
+                        // Do seeded stuff
+                        let seed: u64 = edge_or_seeded[1].decode().unwrap();
+                        let degree: usize = edge_or_seeded[2].decode().unwrap();
+                        let drop_data = tup[2].into_binary().unwrap();
+                        let mut droplet = Droplet::new(DropType::Seeded(seed, degree), drop_data.to_vec());
+                        if decoder_type == tc128() {
+                            droplet_decode(&mut droplet, LDPCCode::TC128, DecoderType::Ms);
+                        } else if decoder_type == tc256() {
+                            droplet_decode(&mut droplet, LDPCCode::TC256, DecoderType::Ms);
+                        } else if decoder_type == tc512() {
+                            droplet_decode(&mut droplet, LDPCCode::TC512, DecoderType::Ms);
+                        } else {
+                            return Err(Error::BadArg)
+                        }
+
+                        match dec.catch(droplet) {
+                            CatchResult::Missing(stats) => {
+                                Ok(
+                                    (missing(),
+                                    (stats.cnt_droplets, stats.cnt_chunks, stats.overhead, stats.unknown_chunks)).encode(env)
+                                )
+                            }
+                            CatchResult::Finished(data, stats) => {
+                                let mut binary = OwnedBinary::new(data.len()).unwrap();
+                                binary.as_mut_slice().write_all(&data).unwrap();
+                                Ok(
+                                    (finished(),
+                                    Binary::from_owned(binary, env),
+                                    (stats.cnt_droplets, stats.cnt_chunks, stats.overhead, stats.unknown_chunks)).encode(env)
+                                )
+                            }
+                        }
+                    } else {
+                        Err(Error::BadArg)
+                    }
+                }
+                _ =>
+                    Err(Error::BadArg)
+            }
+        }
+        _ =>
+            Err(Error::BadArg)
+    }
 }
 
 #[rustler::nif(name = "catch_drop")]

--- a/crates/native/src/lib.rs
+++ b/crates/native/src/lib.rs
@@ -17,9 +17,11 @@ rustler::init!(
     "erlang_fountain",
     [
         encoder::new_encoder,
+        encoder::new_ldpc_encoder,
         encoder::next,
         decoder::new_decoder,
         decoder::catch_drop,
+        decoder::catch_drop_ldpc,
     ],
     load=load
 );

--- a/src/erlang_fountain.erl
+++ b/src/erlang_fountain.erl
@@ -4,10 +4,12 @@
 -export([
          %% Encoding
          new_encoder/3,
+         new_ldpc_encoder/4,
          next/1,
          %% Decoding
          new_decoder/2,
-         catch_drop/2
+         catch_drop/2,
+         catch_drop_ldpc/3
         ]).
 
 %% Native lib support
@@ -21,6 +23,10 @@
 new_encoder(_Data, _Chunk, _Type) ->
     not_loaded(?LINE).
 
+-spec new_ldpc_encoder(Data :: binary(), Chunk :: pos_integer(), Type :: systematic | random, EncType :: tc128 | tc256 | tc512) -> reference().
+new_ldpc_encoder(_Data, _Chunk, _Type, _EncType) ->
+    not_loaded(?LINE).
+
 -spec next(Encoder :: reference()) -> droplet().
 next(_Encoder) ->
     not_loaded(?LINE).
@@ -32,6 +38,11 @@ new_decoder(_Len, _BlockSize) ->
 -spec catch_drop(Decoder :: reference(), Droplet :: droplet()) -> reference().
 catch_drop(_Decoder, _Droplet) ->
     not_loaded(?LINE).
+
+-spec catch_drop_ldpc(Decoder :: reference(), Droplet :: droplet(), DecType :: tc128 | tc256 | tc512) -> reference().
+catch_drop_ldpc(_Decoder, _Droplet, _DecType) ->
+    not_loaded(?LINE).
+
 
 load() ->
     erlang:load_nif(filename:join(priv(), "libnative"), none).

--- a/src/fountain_decoder.erl
+++ b/src/fountain_decoder.erl
@@ -1,6 +1,6 @@
 -module(fountain_decoder).
 
--export([new/2, catch_drop/2]).
+-export([new/2, catch_drop/2, catch_drop/3]).
 
 -type stats() :: { CntDroplets :: non_neg_integer(),
                    CntChunks :: non_neg_integer(),
@@ -17,3 +17,9 @@ new(Len, BlockSize) ->
                  Droplet :: erlang_fountain:droplet()) -> catch_result().
 catch_drop(Decoder, Droplet) ->
     erlang_fountain:catch_drop(Decoder, Droplet).
+
+-spec catch_drop(Decoder :: reference(),
+                 Droplet :: erlang_fountain:droplet(),
+                 DecType :: tc128 | tc256 | tc512) -> catch_result().
+catch_drop(Decoder, Droplet, DecType) ->
+    erlang_fountain:catch_drop_ldpc(Decoder, Droplet, DecType).

--- a/src/fountain_encoder.erl
+++ b/src/fountain_encoder.erl
@@ -1,12 +1,20 @@
 -module(fountain_encoder).
 
--export([new/3, next/1]).
+-export([new/3, new/4, next/1]).
 
 -spec new(Data :: binary(),
           Chunk :: pos_integer(),
           Type :: random | systematic) -> reference().
 new(Data, Chunk, Type) ->
     erlang_fountain:new_encoder(Data, Chunk, Type).
+
+-spec new(Data :: binary(),
+          Chunk :: pos_integer(),
+          Type :: random_ldpc | systematic_ldpc,
+          EncType :: tc128 | tc256 | tc512) -> reference().
+new(Data, Chunk, Type, EncType) ->
+    erlang_fountain:new_ldpc_encoder(Data, Chunk, Type, EncType).
+
 
 -spec next(Encoder :: reference()) -> erlang_fountain:droplet().
 next(Encoder) ->

--- a/test/basic_test.erl
+++ b/test/basic_test.erl
@@ -50,3 +50,48 @@ encode_decode_random_test() ->
                        end, {not_done, <<>>}, lists:seq(1, 5000)),
 
     ?assert(Output == Data).
+
+systematic_ldpc_test() ->
+    NumBytes = 1024,
+    Chunk = 32,
+    Data = crypto:strong_rand_bytes(NumBytes),
+    io:format("Data: ~p~n", [Data]),
+    Encoder = fountain_encoder:new(Data, Chunk, systematic, tc512),
+    Decoder = fountain_decoder:new(NumBytes, Chunk),
+
+    {done, Output} = lists:foldl(
+                       fun(_, {done, Res}) ->
+                               {done, Res};
+                          (_, {not_done, Res}) ->
+                               CatchResult = fountain_decoder:catch_drop(Decoder, fountain_encoder:next(Encoder), tc512),
+                               case CatchResult of
+                                   {missing, _} ->
+                                       {not_done, Res};
+                                   {finished, Ret, _Stats} ->
+                                       {done, Ret}
+                               end
+                       end, {not_done, <<>>}, lists:seq(1, 5000)),
+    ?assert(Output == Data).
+
+random_ldpc_test() ->
+    NumBytes = 1024,
+    Chunk = 32,
+    Data = crypto:strong_rand_bytes(NumBytes),
+    io:format("Data: ~p~n", [Data]),
+    Encoder = fountain_encoder:new(Data, Chunk, random, tc512),
+    Decoder = fountain_decoder:new(NumBytes, Chunk),
+
+    {done, Output} = lists:foldl(
+                       fun(_, {done, Res}) ->
+                               {done, Res};
+                          (_, {not_done, Res}) ->
+                               CatchResult = fountain_decoder:catch_drop(Decoder, fountain_encoder:next(Encoder), tc512),
+                               case CatchResult of
+                                   {missing, _} ->
+                                       {not_done, Res};
+                                   {finished, Ret, _Stats} ->
+                                       {done, Ret}
+                               end
+                       end, {not_done, <<>>}, lists:seq(1, 5000)),
+    ?assert(Output == Data).
+


### PR DESCRIPTION
Update API and rust functionality to support robust and ldpc changes. Also update test to include testing of new fns

API can be seen through the new tests as examples. Essentially we are adding:
1. LDPC encoder types for systematic and random encoder/decoder
2. Encoders utilize a fixed robust soliton distribution to improve fountain performance